### PR TITLE
Add mkdir -p for vim/bundle

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,6 +24,7 @@ ln -f colors ~/.colors
 ln -f git-ps1.sh ~/.git-ps1.sh
 
 if [[ ! -d vim/bundle/vim-colors-solarized ]]; then
+    mkdir -p vim/bundle
     cd vim/bundle
     git clone https://github.com/altercation/vim-colors-solarized.git
     cd ../..


### PR DESCRIPTION
My install failed because this directory wasn't in the repo and wasn't created.  Does it work for you without bundle already in place?
